### PR TITLE
Remove obsolete subset from Capability

### DIFF
--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/outbound/LmosOperatorAgentRegistry.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/outbound/LmosOperatorAgentRegistry.kt
@@ -149,7 +149,6 @@ data class Capability(
     val providedVersion: String,
     val description: String,
     val host: String,
-    val subset: String?,
 )
 
 fun ChannelRouting.toAgent(): List<Agent> {


### PR DESCRIPTION
The subset field was erroneously added to the lmos-router; it has been removed from the router with https://github.com/eclipse-lmos/lmos-operator/pull/45, and needs to be removed here as well.

 Since the field was not used here, no further adaptations are required.

 Resolves #90