### PR TITLE
Update license headers to 2025 and include "and others"

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 
 SPDX-License-Identifier: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ This project has adopted the [Contributor Covenant](https://www.contributor-cove
 By participating in this project, you agree to abide by its [Code of Conduct](./CODE_OF_CONDUCT.md) at all times.
 
 ## Licensing
-Copyright (c) 2024 Deutsche Telekom AG.
+Copyright (c) 2025 Deutsche Telekom AG and others.
 
 Sourcecode licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) (the "License"); you may not use this project except in compliance with the License.
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 version = 1
@@ -11,7 +11,7 @@ path = [
     ".gitignore",
     "*.md"
 ]
-SPDX-FileCopyrightText = "2024 Deutsche Telekom AG"
+SPDX-FileCopyrightText = "2025 Deutsche Telekom AG and others"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/build.gradle.kts
+++ b/lmos-runtime-core/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/LmosRuntimeConfig.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/LmosRuntimeConfig.kt
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/cache/CacheRepository.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/cache/CacheRepository.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/constants/LmosRuntimeConstants.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/constants/LmosRuntimeConstants.kt
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/exception/LmosRuntimeException.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/exception/LmosRuntimeException.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandler.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandler.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/model/Agent.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/model/Agent.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/model/Conversation.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/model/Conversation.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/service/outbound/AgentClientService.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/service/outbound/AgentClientService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/service/outbound/AgentRegistryService.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/service/outbound/AgentRegistryService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/service/outbound/AgentRoutingService.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/service/outbound/AgentRoutingService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/service/routing/ExplicitAgentRoutingService.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/service/routing/ExplicitAgentRoutingService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/outbound/ArcAgentClientService.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/outbound/ArcAgentClientService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/outbound/LmosAgentRoutingService.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/outbound/LmosAgentRoutingService.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/outbound/LmosOperatorAgentRegistry.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/outbound/LmosOperatorAgentRegistry.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/cache/TenantAwareInMemoryCacheTest.kt
+++ b/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/cache/TenantAwareInMemoryCacheTest.kt
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandlerIntegrationTest.kt
+++ b/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandlerIntegrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandlerTest.kt
+++ b/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandlerTest.kt
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/outbound/ArcAgentClientServiceTest.kt
+++ b/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/outbound/ArcAgentClientServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/service/routing/ExplicitAgentRoutingServiceTest.kt
+++ b/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/service/routing/ExplicitAgentRoutingServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/test/resources/mappings/lmos-operator-stub.json.license
+++ b/lmos-runtime-core/src/test/resources/mappings/lmos-operator-stub.json.license
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-core/src/testFixtures/kotlin/ai/ancf/lmos/runtime/test/BaseWireMockTest.kt
+++ b/lmos-runtime-core/src/testFixtures/kotlin/ai/ancf/lmos/runtime/test/BaseWireMockTest.kt
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-service/build.gradle.kts
+++ b/lmos-runtime-service/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.springframework.boot.gradle.tasks.bundling.BootBuildImage
 
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-service/src/main/REUSE.toml
+++ b/lmos-runtime-service/src/main/REUSE.toml
@@ -3,5 +3,5 @@ version = 1
 [[annotations]]
 path = "helm/**"
 precedence = "override"
-SPDX-FileCopyrightText = "2024 Deutsche Telekom AG"
+SPDX-FileCopyrightText = "2025 Deutsche Telekom AG and others"
 SPDX-License-Identifier = "Apache-2.0"

--- a/lmos-runtime-service/src/main/kotlin/org/eclipse/lmos/runtime/service/LmosRuntimeApplication.kt
+++ b/lmos-runtime-service/src/main/kotlin/org/eclipse/lmos/runtime/service/LmosRuntimeApplication.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-service/src/main/kotlin/org/eclipse/lmos/runtime/service/config/CorsConfig.kt
+++ b/lmos-runtime-service/src/main/kotlin/org/eclipse/lmos/runtime/service/config/CorsConfig.kt
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-service/src/main/kotlin/org/eclipse/lmos/runtime/service/constants/LmosServiceConstants.kt
+++ b/lmos-runtime-service/src/main/kotlin/org/eclipse/lmos/runtime/service/constants/LmosServiceConstants.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-service/src/main/kotlin/org/eclipse/lmos/runtime/service/exception/handler/GlobalExceptionHandler.kt
+++ b/lmos-runtime-service/src/main/kotlin/org/eclipse/lmos/runtime/service/exception/handler/GlobalExceptionHandler.kt
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-service/src/main/kotlin/org/eclipse/lmos/runtime/service/inbound/controller/ConversationController.kt
+++ b/lmos-runtime-service/src/main/kotlin/org/eclipse/lmos/runtime/service/inbound/controller/ConversationController.kt
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-service/src/main/kotlin/org/eclipse/lmos/runtime/service/properties/LmosRuntimeCorsProperties.kt
+++ b/lmos-runtime-service/src/main/kotlin/org/eclipse/lmos/runtime/service/properties/LmosRuntimeCorsProperties.kt
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-service/src/main/resources/application-local.yml
+++ b/lmos-runtime-service/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 #
-# // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 # //
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/lmos-runtime-service/src/main/resources/application.yaml
+++ b/lmos-runtime-service/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 # //
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/lmos-runtime-service/src/test/kotlin/org/eclipse/lmos/runtime/service/exception/handler/GlobalExceptionHandlerTest.kt
+++ b/lmos-runtime-service/src/test/kotlin/org/eclipse/lmos/runtime/service/exception/handler/GlobalExceptionHandlerTest.kt
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-service/src/test/kotlin/org/eclipse/lmos/runtime/service/inbound/controller/ConversationControllerIntegrationTest.kt
+++ b/lmos-runtime-service/src/test/kotlin/org/eclipse/lmos/runtime/service/inbound/controller/ConversationControllerIntegrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-service/src/test/kotlin/org/eclipse/lmos/runtime/service/inbound/controller/ConversationControllerTest.kt
+++ b/lmos-runtime-service/src/test/kotlin/org/eclipse/lmos/runtime/service/inbound/controller/ConversationControllerTest.kt
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-service/src/test/resources/application.yaml
+++ b/lmos-runtime-service/src/test/resources/application.yaml
@@ -1,4 +1,4 @@
-#SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+#SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 #SPDX-License-Identifier: Apache-2.0
 

--- a/lmos-runtime-service/src/test/resources/mappings/lmos-operator-stub.json.license
+++ b/lmos-runtime-service/src/test/resources/mappings/lmos-operator-stub.json.license
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-spring-boot-starter/build.gradle.kts
+++ b/lmos-runtime-spring-boot-starter/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/runtime/config/LmosRuntimeAutoConfiguration.kt
+++ b/lmos-runtime-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/runtime/config/LmosRuntimeAutoConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/runtime/properties/LmosRuntimeProperties.kt
+++ b/lmos-runtime-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/runtime/properties/LmosRuntimeProperties.kt
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/lmos-runtime-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 #
 # SPDX-License-Identifier: Apache-2.0
 org.eclipse.lmos.runtime.config.LmosRuntimeAutoConfiguration

--- a/lmos-runtime-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/runtime/inbound/LmosRuntimeAutoConfigurationCustomBeansTest.kt
+++ b/lmos-runtime-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/runtime/inbound/LmosRuntimeAutoConfigurationCustomBeansTest.kt
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/runtime/inbound/LmosRuntimeAutoConfigurationTest.kt
+++ b/lmos-runtime-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/runtime/inbound/LmosRuntimeAutoConfigurationTest.kt
@@ -1,5 +1,5 @@
 /*
- * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  * //
  * // SPDX-License-Identifier: Apache-2.0
  */

--- a/lmos-runtime-spring-boot-starter/src/test/resources/application-test.yml
+++ b/lmos-runtime-spring-boot-starter/src/test/resources/application-test.yml
@@ -1,5 +1,5 @@
 #
-# // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+# // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
 # //
 # // SPDX-License-Identifier: Apache-2.0
 #

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
  *
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
See https://www.eclipse.org/projects/handbook/#ip-copyright-headers