### PR TITLE
Permit to build docker image locally (without publishing to some registry)

### DIFF
--- a/lmos-runtime-service/build.gradle.kts
+++ b/lmos-runtime-service/build.gradle.kts
@@ -32,19 +32,24 @@ dependencies {
 }
 
 tasks.named<BootBuildImage>("bootBuildImage") {
-    val registryUrl = getProperty("REGISTRY_URL")
-    val registryUsername = getProperty("REGISTRY_USERNAME")
-    val registryPassword = getProperty("REGISTRY_PASSWORD")
-    val registryNamespace = getProperty("REGISTRY_NAMESPACE")
+    if (project.hasProperty("REGISTRY_URL")) {
+        val registryUrl = getProperty("REGISTRY_URL")
+        val registryUsername = getProperty("REGISTRY_USERNAME")
+        val registryPassword = getProperty("REGISTRY_PASSWORD")
+        val registryNamespace = getProperty("REGISTRY_NAMESPACE")
 
-    imageName.set("$registryUrl/$registryNamespace/${rootProject.name}:${project.version}")
-    publish = true
-    docker {
-        publishRegistry {
-            url.set(registryUrl)
-            username.set(registryUsername)
-            password.set(registryPassword)
+        imageName.set("$registryUrl/$registryNamespace/${rootProject.name}:${project.version}")
+        publish = true
+        docker {
+            publishRegistry {
+                url.set(registryUrl)
+                username.set(registryUsername)
+                password.set(registryPassword)
+            }
         }
+    } else {
+        imageName.set("${rootProject.name}:${project.version}")
+        publish = false
     }
 }
 


### PR DESCRIPTION
The purpose of this change is to ease local development (e.g., to be able to use the docker image in minikube without having to publish to some registry first, or the need to enable the miniube registry addon).