### PR TITLE
Remove x-subset header from sample in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ To interact with LMOS Runtime, send a POST request to the chat endpoint:
 curl -X POST "http://127.0.0.1:<port>/lmos/runtime/apis/v1/<tenant>/chat/<conversationId>/message" \
      -H "Content-Type: application/json" \
      -H "x-turn-id: <turnId>" \
-     -H "x-subset: stable" \
      -d '{
            "inputContext": {
              "messages": [


### PR DESCRIPTION
Why? The x-subset header is sent from the lmos-runtime to the lmos-operator; it is not included in requests to the lmos-runtime itself.