### PR TITLE
Permit configuring the LLM provider used in lmos-router

### DIFF
--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/LmosRuntimeConfig.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/LmosRuntimeConfig.kt
@@ -16,6 +16,7 @@ open class LmosRuntimeConfig(
     )
 
     data class OpenAI(
+        val provider: String,
         val url: String,
         val key: String,
         val model: String,

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/outbound/LmosAgentRoutingService.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/outbound/LmosAgentRoutingService.kt
@@ -60,6 +60,7 @@ class LmosAgentRoutingService(private val lmosRuntimeConfig: LmosRuntimeConfig) 
         val openAIConfig = lmosRuntimeConfig.openAi ?: throw IllegalArgumentException("openAI configuration key is null")
         val defaultModelClientProperties =
             DefaultModelClientProperties(
+                provider = openAIConfig.provider,
                 openAiUrl = openAIConfig.url,
                 openAiApiKey = openAIConfig.key,
                 model = openAIConfig.model,

--- a/lmos-runtime-service/src/main/resources/application.yaml
+++ b/lmos-runtime-service/src/main/resources/application.yaml
@@ -11,6 +11,7 @@ lmos:
     router:
       type: EXPLICIT
     open-ai:
+      provider: ${OPENAI_API_PROVIDER:openai}
       url: ${OPENAI_API_URL:https://api.openai.com/v1}
       key: ${OPENAI_API_KEY:}
       model: ${OPENAI_API_MODEL:"gpt-3.5-turbo"}

--- a/lmos-runtime-spring-boot-starter/src/test/resources/application-test.yml
+++ b/lmos-runtime-spring-boot-starter/src/test/resources/application-test.yml
@@ -7,6 +7,7 @@
 lmos:
   runtime:
     open-ai:
+      provider: openai
       key: dummyKey
       url: https://localhost:8080/openai
       max-tokens: 1000


### PR DESCRIPTION
Currently, the lmos-runtime can only be configured to use the OpenAI provider when using LLM-based routing in lmos-router. With this commit, it should be possible to configure the provider (the default remaining the OpenAI provider).