### PR TITLE
Use Kotlin's IO dispatcher when calling lmos-router to resolve agents.

### DIFF
--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/outbound/LmosAgentRoutingService.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/outbound/LmosAgentRoutingService.kt
@@ -6,6 +6,8 @@
 
 package org.eclipse.lmos.runtime.outbound
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.eclipse.lmos.router.core.*
 import org.eclipse.lmos.router.llm.DefaultModelClient
 import org.eclipse.lmos.router.llm.DefaultModelClientProperties
@@ -29,7 +31,7 @@ class LmosAgentRoutingService(private val lmosRuntimeConfig: LmosRuntimeConfig) 
         val (context, input) = prepareConversationComponents(conversation)
 
         val agentRoutingSpec =
-            resolveAgent(agentRoutingSpecResolver, context, input)
+            withContext(Dispatchers.IO) { resolveAgent(agentRoutingSpecResolver, context, input)}
         log.info("Resolved agent: $agentRoutingSpec")
         return agentRoutingSpec?.toAgent() ?: throw AgentRoutingSpecResolverException("No agent resolved for user query")
     }

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/outbound/LmosAgentRoutingService.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/outbound/LmosAgentRoutingService.kt
@@ -9,6 +9,7 @@ package org.eclipse.lmos.runtime.outbound
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.eclipse.lmos.router.core.*
+import org.eclipse.lmos.router.core.Capability
 import org.eclipse.lmos.router.llm.DefaultModelClient
 import org.eclipse.lmos.router.llm.DefaultModelClientProperties
 import org.eclipse.lmos.router.llm.LLMAgentRoutingSpecsResolver
@@ -31,7 +32,7 @@ class LmosAgentRoutingService(private val lmosRuntimeConfig: LmosRuntimeConfig) 
         val (context, input) = prepareConversationComponents(conversation)
 
         val agentRoutingSpec =
-            withContext(Dispatchers.IO) { resolveAgent(agentRoutingSpecResolver, context, input)}
+            withContext(Dispatchers.IO) { resolveAgent(agentRoutingSpecResolver, context, input) }
         log.info("Resolved agent: $agentRoutingSpec")
         return agentRoutingSpec?.toAgent() ?: throw AgentRoutingSpecResolverException("No agent resolved for user query")
     }

--- a/lmos-runtime-service/src/test/kotlin/org/eclipse/lmos/runtime/service/inbound/controller/AbstractConversationControllerIntegrationTest.kt
+++ b/lmos-runtime-service/src/test/kotlin/org/eclipse/lmos/runtime/service/inbound/controller/AbstractConversationControllerIntegrationTest.kt
@@ -34,11 +34,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import java.util.*
 
-@SpringBootTest
-@ActiveProfiles("test")
-@AutoConfigureWebTestClient
-@Import
-class ConversationControllerIntegrationTest : BaseWireMockTest() {
+abstract class AbstractConversationControllerIntegrationTest : BaseWireMockTest() {
     @Autowired
     private lateinit var webTestClient: WebTestClient
 

--- a/lmos-runtime-service/src/test/kotlin/org/eclipse/lmos/runtime/service/inbound/controller/AbstractConversationControllerIntegrationTest.kt
+++ b/lmos-runtime-service/src/test/kotlin/org/eclipse/lmos/runtime/service/inbound/controller/AbstractConversationControllerIntegrationTest.kt
@@ -23,13 +23,9 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import java.util.*

--- a/lmos-runtime-service/src/test/kotlin/org/eclipse/lmos/runtime/service/inbound/controller/ConversationControllerExplicitAgentRoutingIntegrationTest.kt
+++ b/lmos-runtime-service/src/test/kotlin/org/eclipse/lmos/runtime/service/inbound/controller/ConversationControllerExplicitAgentRoutingIntegrationTest.kt
@@ -1,0 +1,41 @@
+/*
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+ * //
+ * // SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.lmos.runtime.service.inbound.controller
+
+import io.mockk.*
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import org.eclipse.lmos.arc.agent.client.graphql.GraphQlAgentClient
+import org.eclipse.lmos.arc.api.AgentRequest
+import org.eclipse.lmos.arc.api.AgentResult
+import org.eclipse.lmos.arc.api.Message
+import org.eclipse.lmos.runtime.core.model.*
+import org.eclipse.lmos.runtime.outbound.ArcAgentClientService
+import org.eclipse.lmos.runtime.service.constants.LmosServiceConstants.Endpoints.BASE_PATH
+import org.eclipse.lmos.runtime.service.constants.LmosServiceConstants.Endpoints.CHAT_URL
+import org.eclipse.lmos.runtime.service.constants.LmosServiceConstants.Headers.TURN_ID
+import org.eclipse.lmos.runtime.test.BaseWireMockTest
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import java.util.*
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureWebTestClient
+@Import(AbstractConversationControllerIntegrationTest.TestConfig::class)
+class ConversationControllerExplicitAgentRoutingIntegrationTest : AbstractConversationControllerIntegrationTest()

--- a/lmos-runtime-service/src/test/kotlin/org/eclipse/lmos/runtime/service/inbound/controller/ConversationControllerExplicitAgentRoutingIntegrationTest.kt
+++ b/lmos-runtime-service/src/test/kotlin/org/eclipse/lmos/runtime/service/inbound/controller/ConversationControllerExplicitAgentRoutingIntegrationTest.kt
@@ -6,32 +6,11 @@
 package org.eclipse.lmos.runtime.service.inbound.controller
 
 import io.mockk.*
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.runBlocking
-import org.eclipse.lmos.arc.agent.client.graphql.GraphQlAgentClient
-import org.eclipse.lmos.arc.api.AgentRequest
-import org.eclipse.lmos.arc.api.AgentResult
-import org.eclipse.lmos.arc.api.Message
 import org.eclipse.lmos.runtime.core.model.*
-import org.eclipse.lmos.runtime.outbound.ArcAgentClientService
-import org.eclipse.lmos.runtime.service.constants.LmosServiceConstants.Endpoints.BASE_PATH
-import org.eclipse.lmos.runtime.service.constants.LmosServiceConstants.Endpoints.CHAT_URL
-import org.eclipse.lmos.runtime.service.constants.LmosServiceConstants.Headers.TURN_ID
-import org.eclipse.lmos.runtime.test.BaseWireMockTest
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
-import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.reactive.server.WebTestClient
-import org.springframework.test.web.reactive.server.expectBody
 import java.util.*
 
 @SpringBootTest

--- a/lmos-runtime-service/src/test/kotlin/org/eclipse/lmos/runtime/service/inbound/controller/ConversationControllerLlmBasedRoutingIntegrationTest.kt
+++ b/lmos-runtime-service/src/test/kotlin/org/eclipse/lmos/runtime/service/inbound/controller/ConversationControllerLlmBasedRoutingIntegrationTest.kt
@@ -6,43 +6,25 @@
 package org.eclipse.lmos.runtime.service.inbound.controller
 
 import io.mockk.*
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.runBlocking
-import org.eclipse.lmos.arc.agent.client.graphql.GraphQlAgentClient
-import org.eclipse.lmos.arc.api.AgentRequest
-import org.eclipse.lmos.arc.api.AgentResult
-import org.eclipse.lmos.arc.api.Message
 import org.eclipse.lmos.runtime.core.model.*
-import org.eclipse.lmos.runtime.outbound.ArcAgentClientService
-import org.eclipse.lmos.runtime.service.constants.LmosServiceConstants.Endpoints.BASE_PATH
-import org.eclipse.lmos.runtime.service.constants.LmosServiceConstants.Endpoints.CHAT_URL
-import org.eclipse.lmos.runtime.service.constants.LmosServiceConstants.Headers.TURN_ID
-import org.eclipse.lmos.runtime.test.BaseWireMockTest
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
-import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.reactive.server.WebTestClient
-import org.springframework.test.web.reactive.server.expectBody
 import java.util.*
 
-@SpringBootTest(properties = [
-    "lmos.runtime.router.type=llm",
-    "lmos.runtime.open-ai.provider=other",
-    "lmos.runtime.open-ai.key=some-api-key",
-    "lmos.runtime.open-ai.url=http://localhost:8080/llm",
-    "lmos.runtime.open-ai.model=some-model",
-    "lmos.runtime.open-ai.max-tokens=2000",
-    "lmos.runtime.open-ai.temperature=2.0",
-    "lmos.runtime.open-ai.format=json_object"])
+@SpringBootTest(
+    properties = [
+        "lmos.runtime.router.type=llm",
+        "lmos.runtime.open-ai.provider=other",
+        "lmos.runtime.open-ai.key=some-api-key",
+        "lmos.runtime.open-ai.url=http://localhost:8080/llm",
+        "lmos.runtime.open-ai.model=some-model",
+        "lmos.runtime.open-ai.max-tokens=2000",
+        "lmos.runtime.open-ai.temperature=2.0",
+        "lmos.runtime.open-ai.format=json_object",
+    ],
+)
 @ActiveProfiles("test")
 @AutoConfigureWebTestClient
 @Import(AbstractConversationControllerIntegrationTest.TestConfig::class)

--- a/lmos-runtime-service/src/test/kotlin/org/eclipse/lmos/runtime/service/inbound/controller/ConversationControllerLlmBasedRoutingIntegrationTest.kt
+++ b/lmos-runtime-service/src/test/kotlin/org/eclipse/lmos/runtime/service/inbound/controller/ConversationControllerLlmBasedRoutingIntegrationTest.kt
@@ -1,0 +1,49 @@
+/*
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+ * //
+ * // SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.lmos.runtime.service.inbound.controller
+
+import io.mockk.*
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import org.eclipse.lmos.arc.agent.client.graphql.GraphQlAgentClient
+import org.eclipse.lmos.arc.api.AgentRequest
+import org.eclipse.lmos.arc.api.AgentResult
+import org.eclipse.lmos.arc.api.Message
+import org.eclipse.lmos.runtime.core.model.*
+import org.eclipse.lmos.runtime.outbound.ArcAgentClientService
+import org.eclipse.lmos.runtime.service.constants.LmosServiceConstants.Endpoints.BASE_PATH
+import org.eclipse.lmos.runtime.service.constants.LmosServiceConstants.Endpoints.CHAT_URL
+import org.eclipse.lmos.runtime.service.constants.LmosServiceConstants.Headers.TURN_ID
+import org.eclipse.lmos.runtime.test.BaseWireMockTest
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import java.util.*
+
+@SpringBootTest(properties = [
+    "lmos.runtime.router.type=llm",
+    "lmos.runtime.open-ai.provider=other",
+    "lmos.runtime.open-ai.key=some-api-key",
+    "lmos.runtime.open-ai.url=http://localhost:8080/llm",
+    "lmos.runtime.open-ai.model=some-model",
+    "lmos.runtime.open-ai.max-tokens=2000",
+    "lmos.runtime.open-ai.temperature=2.0",
+    "lmos.runtime.open-ai.format=json_object"])
+@ActiveProfiles("test")
+@AutoConfigureWebTestClient
+@Import(AbstractConversationControllerIntegrationTest.TestConfig::class)
+class ConversationControllerLlmBasedRoutingIntegrationTest : AbstractConversationControllerIntegrationTest()

--- a/lmos-runtime-service/src/test/resources/mappings/openai-api-stub.json
+++ b/lmos-runtime-service/src/test/resources/mappings/openai-api-stub.json
@@ -1,0 +1,30 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/llm/chat/completions"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "id": "chatcmpl-7a1b2c3d4e",
+      "object": "chat.completion",
+      "created": 1677654321,
+      "model": "gpt-4",
+      "choices": [
+        {
+          "index": 0,
+          "message": { "role": "assistant", "content": "{\"agentName\": \"SummaryAgent\"}" },
+          "finish_reason": "stop"
+        }
+      ],
+      "usage": {
+        "prompt_tokens": 15,
+        "completion_tokens": 9,
+        "total_tokens": 24
+      }
+    }
+  }
+}


### PR DESCRIPTION
The goal of this change is to deal with potentially blocking calls that might occur within lmos-router when calling LLMs.

Addresses #98