### PR TITLE
Add missing license file for openai-api-stub.json

### DIFF
--- a/lmos-runtime-service/src/test/resources/mappings/openai-api-stub.json.license
+++ b/lmos-runtime-service/src/test/resources/mappings/openai-api-stub.json.license
@@ -1,0 +1,5 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */


### PR DESCRIPTION
Thanks for the hint, @RobWin, that this license header was still missing.