### PR TITLE
Add option to create the lmos-runtime secret by the helm chart

### DIFF
--- a/lmos-runtime-service/src/main/helm/templates/secret.yaml
+++ b/lmos-runtime-service/src/main/helm/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.createSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secretName }}
+  labels:
+    {{- include "lmos-runtime.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.secretKey }}: {{ .Values.secretApiKey | b64enc }}
+{{- end }}

--- a/lmos-runtime-service/src/main/helm/values.yaml
+++ b/lmos-runtime-service/src/main/helm/values.yaml
@@ -95,5 +95,10 @@ tolerations: []
 
 affinity: {}
 
+# Set to true if the secret containing the LLM API key should be created by helm.
+# If set to false, a secret named <secretName> and providing the LLM API key in <secretKey> must be available in the cluster.
+# If set to true, a secret named <secretName> containing the LLM API key <secretApiKey> will be created.
+createSecret: false
 secretName: "lmos-runtime"
 secretKey: "OPENAI_API_KEY"
+# secretApiKey: API key to be used with LLM for LLM-based routing


### PR DESCRIPTION
The default is still to not create a secret and instead require the secret to be available in the cluster when installing lmos-runtime via helm.

Resolves #104