### PR TITLE
Add cors to graphql service

### DIFF
--- a/lmos-runtime-graphql-service/src/main/kotlin/org/eclipse/lmos/runtime/graphql/service/LmosRuntimeGraphQLApplication.kt
+++ b/lmos-runtime-graphql-service/src/main/kotlin/org/eclipse/lmos/runtime/graphql/service/LmosRuntimeGraphQLApplication.kt
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.eclipse.lmos.runtime.graphql.service.inbound.subscription
+package org.eclipse.lmos.runtime.graphql.service
 
 import org.eclipse.lmos.runtime.graphql.service.properties.LmosRuntimeCorsProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication

--- a/lmos-runtime-graphql-service/src/main/kotlin/org/eclipse/lmos/runtime/graphql/service/config/CorsConfig.kt
+++ b/lmos-runtime-graphql-service/src/main/kotlin/org/eclipse/lmos/runtime/graphql/service/config/CorsConfig.kt
@@ -1,0 +1,28 @@
+/*
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+ * //
+ * // SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.lmos.runtime.graphql.service.config
+
+import org.eclipse.lmos.runtime.graphql.service.properties.LmosRuntimeCorsProperties
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.config.CorsRegistry
+import org.springframework.web.reactive.config.WebFluxConfigurer
+
+@Configuration
+open class CorsConfig(private val runtimeCorsProperties: LmosRuntimeCorsProperties) : WebFluxConfigurer {
+    override fun addCorsMappings(registry: CorsRegistry) {
+        if (runtimeCorsProperties.enabled) {
+            runtimeCorsProperties.patterns.forEach { pattern ->
+                registry
+                    .addMapping(pattern)
+                    .allowedOrigins(*runtimeCorsProperties.allowedOrigins.toTypedArray())
+                    .allowedMethods(*runtimeCorsProperties.allowedMethods.toTypedArray())
+                    .allowedHeaders(*runtimeCorsProperties.allowedHeaders.toTypedArray())
+                    .maxAge(runtimeCorsProperties.maxAge)
+            }
+        }
+    }
+}

--- a/lmos-runtime-graphql-service/src/main/kotlin/org/eclipse/lmos/runtime/graphql/service/inbound/subscription/LmosRuntimeGraphQLApplication.kt
+++ b/lmos-runtime-graphql-service/src/main/kotlin/org/eclipse/lmos/runtime/graphql/service/inbound/subscription/LmosRuntimeGraphQLApplication.kt
@@ -5,10 +5,13 @@
  */
 package org.eclipse.lmos.runtime.graphql.service.inbound.subscription
 
+import org.eclipse.lmos.runtime.graphql.service.properties.LmosRuntimeCorsProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
+@EnableConfigurationProperties(value = [LmosRuntimeCorsProperties::class])
 open class LmosRuntimeGraphQLApplication
 
 fun main(args: Array<String>) {

--- a/lmos-runtime-graphql-service/src/main/kotlin/org/eclipse/lmos/runtime/graphql/service/properties/LmosRuntimeCorsProperties.kt
+++ b/lmos-runtime-graphql-service/src/main/kotlin/org/eclipse/lmos/runtime/graphql/service/properties/LmosRuntimeCorsProperties.kt
@@ -1,0 +1,19 @@
+/*
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+ * //
+ * // SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.lmos.runtime.graphql.service.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "lmos.runtime.cors")
+class LmosRuntimeCorsProperties(
+    var enabled: Boolean = false,
+    var allowedOrigins: List<String> = emptyList(),
+    var allowedMethods: List<String> = emptyList(),
+    var allowedHeaders: List<String> = emptyList(),
+    var patterns: List<String> = emptyList(),
+    var maxAge: Long = 8000,
+)

--- a/lmos-runtime-graphql-service/src/main/resources/application.yaml
+++ b/lmos-runtime-graphql-service/src/main/resources/application.yaml
@@ -19,6 +19,13 @@ lmos:
       format: ${OPENAI_API_FORMAT:json_object}
     cache:
       ttl: ${CACHE_TTL:1800}
+    cors:
+      enabled: ${CORS_ENABLED:false}
+      allowed-origins: ${CORS_ALLOWED_ORIGINS:*}
+      allowed-methods: ${CORS_ALLOWED_METHODS:*}
+      allowed-headers: ${CORS_ALLOWED_HEADERS:*}
+      patterns: ${CORS_PATTERNS:/**}
+      max-age: ${CORS_MAX_AGE:8000}
 
 server:
   port: 8081


### PR DESCRIPTION
Why? Because we need cors support when we want to talk to the lmos-runtime from, e.g., the arc-view.