### PR TITLE
Adapt the graphql interface of the lmos-runtime to the graphql schema spoken by arc agents

### DIFF
--- a/lmos-runtime-graphql-service/src/main/kotlin/org/eclipse/lmos/runtime/graphql/service/inbound/subscription/AgentQuery.kt
+++ b/lmos-runtime-graphql-service/src/main/kotlin/org/eclipse/lmos/runtime/graphql/service/inbound/subscription/AgentQuery.kt
@@ -1,0 +1,24 @@
+/*
+ * // SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+ * //
+ * // SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.lmos.runtime.graphql.service.inbound.subscription
+
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
+import com.expediagroup.graphql.server.operations.Query
+import org.springframework.stereotype.Component
+
+/**
+ * Query to get the list of agents provided by a service.
+ */
+@Component
+class ChatQuery : Query {
+    @GraphQLDescription("The single agent interface provided by the lmos-runtime")
+    fun agent(): Agents {
+        return Agents(listOf("lmos-runtime"))
+    }
+}
+
+data class Agents(val names: List<String>)

--- a/lmos-runtime-graphql-service/src/main/kotlin/org/eclipse/lmos/runtime/graphql/service/inbound/subscription/ConversationSubscription.kt
+++ b/lmos-runtime-graphql-service/src/main/kotlin/org/eclipse/lmos/runtime/graphql/service/inbound/subscription/ConversationSubscription.kt
@@ -10,31 +10,63 @@ import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.server.operations.Subscription
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.flow
+import org.eclipse.lmos.arc.api.AgentRequest
+import org.eclipse.lmos.arc.api.AgentResult
+import org.eclipse.lmos.arc.api.Message
 import org.eclipse.lmos.runtime.core.inbound.ConversationHandler
-import org.eclipse.lmos.runtime.core.model.Conversation
+import org.eclipse.lmos.runtime.core.model.*
 import org.springframework.stereotype.Component
 
 @Component
 class ConversationSubscription(private val conversationHandler: ConversationHandler) : Subscription {
     @GraphQLDescription("Processes the user input and returns the result")
-    suspend fun chat(
-        conversation: Conversation,
-        conversationId: String,
-        tenantId: String,
-        turnId: String,
+    suspend fun agent(
+        agentName: String? = null,
+        request: AgentRequest,
     ) = flow {
         coroutineScope {
             val assistantMessageFlow =
                 conversationHandler.handleConversation(
-                    conversation,
-                    conversationId,
-                    tenantId,
-                    turnId,
+                    conversation = request.toConversation(),
+                    conversationId = request.conversationContext.conversationId,
+                    tenantId = request.systemContext.first { it.key == "tenantId" }.value,
+                    turnId = request.conversationContext.turnId ?: "unknown turnId",
                 )
 
             assistantMessageFlow.collect {
-                emit(it)
+                emit(
+                    AgentResult(
+                        messages =
+                            listOf(
+                                Message(
+                                    role = "assistant",
+                                    content = it.content,
+                                    turnId = request.conversationContext.turnId,
+                                ),
+                            ),
+                    ),
+                )
             }
         }
     }
 }
+
+private fun AgentRequest.toConversation() =
+    Conversation(
+        inputContext =
+            InputContext(
+                messages = this.messages,
+                anonymizationEntities = this.conversationContext.anonymizationEntities,
+            ),
+        systemContext =
+            SystemContext(
+                channelId = this.systemContext.first { it.key == "channelId" }.value,
+                contextParams = this.systemContext.map { KeyValuePair(it.key, it.value) },
+            ),
+        userContext =
+            UserContext(
+                userId = this.userContext.userId ?: throw IllegalArgumentException("missing user id"),
+                userToken = this.userContext.userToken,
+                contextParams = this.userContext.profile.map { KeyValuePair(it.key, it.value) },
+            ),
+    )


### PR DESCRIPTION
Adapt the graphql interface of the lmos-runtime to the graphql schema spoken by arc agents (and the arc view).

This includes:_
* Adding a graphql query which returns the "agent name" of the lmos-runtime.
* Adapt the chat subscription to use arc's graphql schema. To handle the schema used by arc, but keep the internal interfaces of the runtime, arc's schema is mapped to the runtime-internal schema (and back).