### PR TITLE
Address kotlinx.serialization in interplay with arc

### DIFF
--- a/lmos-runtime-core/build.gradle.kts
+++ b/lmos-runtime-core/build.gradle.kts
@@ -12,17 +12,17 @@ dependencies {
     val arcVersion = "0.1.0-SNAPSHOT"
     val lmosRouterVersion = "0.1.0-SNAPSHOT"
 
-    val ktorVersion = "2.3.12"
+    val ktorVersion = "3.1.0"
     val junitVersion = "5.9.3"
 
     implementation("io.ktor:ktor-client-cio:$ktorVersion")
     implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
     implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.8.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.8.1")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.2")
     implementation("org.slf4j:slf4j-api:1.7.25")
-    api("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.7.3")
+    api("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.8.0")
     api("org.eclipse.lmos:lmos-router-llm:$lmosRouterVersion")
     api("org.eclipse.lmos:arc-agent-client:$arcVersion")
     api("org.eclipse.lmos:arc-api:$arcVersion")

--- a/lmos-runtime-graphql-service/build.gradle.kts
+++ b/lmos-runtime-graphql-service/build.gradle.kts
@@ -33,6 +33,18 @@ dependencies {
     testImplementation("app.cash.turbine:turbine:1.2.0")
 }
 
+// Set kotlinx-serialization version in dependencyManagement to overrule the dependency management of spring boot plugin.
+// Can be omitted again when spring boot has upgraded to more recent kotlinx-serialization version.
+dependencyManagement {
+    dependencies {
+        dependency("org.jetbrains.kotlinx:kotlinx-serialization-bom:1.8.0")
+        dependency("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
+        dependency("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.8.0")
+        dependency("org.jetbrains.kotlinx:kotlinx-serialization-core:1.8.0")
+        dependency("org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.8.0")
+    }
+}
+
 tasks.named<BootBuildImage>("bootBuildImage") {
     val registryUrl = getProperty("REGISTRY_URL")
     val registryUsername = getProperty("REGISTRY_USERNAME")

--- a/lmos-runtime-service/build.gradle.kts
+++ b/lmos-runtime-service/build.gradle.kts
@@ -31,6 +31,18 @@ dependencies {
     testImplementation("com.marcinziolo:kotlin-wiremock:2.1.1")
 }
 
+// Set kotlinx-serialization version in dependencyManagement to overrule the dependency management of spring boot plugin.
+// Can be omitted again when spring boot has upgraded to more recent kotlinx-serialization version.
+dependencyManagement {
+    dependencies {
+        dependency("org.jetbrains.kotlinx:kotlinx-serialization-bom:1.8.0")
+        dependency("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
+        dependency("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.8.0")
+        dependency("org.jetbrains.kotlinx:kotlinx-serialization-core:1.8.0")
+        dependency("org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.8.0")
+    }
+}
+
 tasks.named<BootBuildImage>("bootBuildImage") {
     if (project.hasProperty("REGISTRY_URL")) {
         val registryUrl = getProperty("REGISTRY_URL")


### PR DESCRIPTION
Ktor was already upgraded to version 3.x in arc (cf.  https://github.com/eclipse-lmos/arc/commit/dd771763333fe4899589d34b3e78336e21741e4a) - and this leads to incompatibilities with different versions of kotlinx.serialization being used in lmos-runtime and in the arc libraries pulled in by the lmos-runtime.

More concretely, when deserializing JSON documents using classes from the arc libraries, errors about missing methods are thrown (because the classes from the arc libraries were generated using a different version of kotlinx.serialization than the version used by the lmos-runtime). Errors like this one occur:

> Receiver class org.eclipse.lmos.arc.api.Message$$serializer does not define or inherit an implementation of the resolved method 'abstract kotlinx.serialization.KSerializer[] typeParametersSerializers()' of interface kotlinx.serialization.internal.GeneratedSerializer

To address this, the ktor version in the runtime is also upgraded to 3.x, and the kotlinx.serialization version is increased to 1.8.0.

As spring boot's gradle plugin manages the kotlinx.serialization version, we need to use a dependencyManagement block in the two modules pulling in that plugin to actually increase the version of kotlinx.serialization.