### PR TITLE
Make openai-provider configurable in helm chart

### DIFF
--- a/lmos-runtime-graphql-service/src/main/helm/templates/configmap.yaml
+++ b/lmos-runtime-graphql-service/src/main/helm/templates/configmap.yaml
@@ -3,6 +3,10 @@ kind: ConfigMap
 metadata:
   name: {{ include "lmos-runtime.fullname" . }}-config
 data:
+  {{- if .Values.openaiApiProvider }}
+  LMOS_RUNTIME_OPENAI_PROVIDER: {{ .Values.openaiApiProvider | quote }}
+  {{- end }}
+
   {{- if .Values.openaiApiUrl }}
   LMOS_RUNTIME_OPENAI_URL: {{ .Values.openaiApiUrl | quote }}
   {{- end }}

--- a/lmos-runtime-graphql-service/src/main/resources/application.yaml
+++ b/lmos-runtime-graphql-service/src/main/resources/application.yaml
@@ -11,6 +11,7 @@ lmos:
     router:
       type: EXPLICIT
     open-ai:
+      provider: ${OPENAI_API_PROVIDER:openai}
       url: ${OPENAI_API_URL:https://api.openai.com/v1}
       key: ${OPENAI_API_KEY:}
       model: ${OPENAI_API_MODEL:"gpt-3.5-turbo"}

--- a/lmos-runtime-service/src/main/helm/templates/configmap.yaml
+++ b/lmos-runtime-service/src/main/helm/templates/configmap.yaml
@@ -3,6 +3,10 @@ kind: ConfigMap
 metadata:
   name: {{ include "lmos-runtime.fullname" . }}-config
 data:
+  {{- if .Values.openaiApiProvider }}
+  LMOS_RUNTIME_OPENAI_PROVIDER: {{ .Values.openaiApiProvider | quote }}
+  {{- end }}
+
   {{- if .Values.openaiApiUrl }}
   LMOS_RUNTIME_OPENAI_URL: {{ .Values.openaiApiUrl | quote }}
   {{- end }}


### PR DESCRIPTION
Also, add missing provider default value to graphql-servicer application.yaml (otherwise, it won't start without setting the provider in the environment explicitly).