### PR TITLE
feat(runtime): Add subset parameter support to ConversationHandler

### DIFF
--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandler.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandler.kt
@@ -27,6 +27,7 @@ interface ConversationHandler {
         conversationId: String,
         tenantId: String,
         turnId: String,
+        subset: String? = null,
     ): Flow<AssistantMessage>
 }
 
@@ -44,13 +45,14 @@ class DefaultConversationHandler(
         conversationId: String,
         tenantId: String,
         turnId: String,
+        subset: String?,
     ): Flow<AssistantMessage> =
         coroutineScope {
             log.debug("Request Received, conversationId: $conversationId, turnId: $turnId")
             val routingInformation =
                 lmosRuntimeTenantAwareCache.get(tenantId, ROUTES, conversationId)
                     ?: agentRegistryService
-                        .getRoutingInformation(tenantId, conversation.systemContext.channelId)
+                        .getRoutingInformation(tenantId, conversation.systemContext.channelId, subset)
                         .also { result ->
                             log.debug("Caching routing information: {}", result)
                             lmosRuntimeTenantAwareCache.save(

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandler.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandler.kt
@@ -49,20 +49,35 @@ class DefaultConversationHandler(
     ): Flow<AssistantMessage> =
         coroutineScope {
             log.debug("Request Received, conversationId: $conversationId, turnId: $turnId")
-            val routingInformation =
-                lmosRuntimeTenantAwareCache.get(tenantId, ROUTES, conversationId)
-                    ?: agentRegistryService
-                        .getRoutingInformation(tenantId, conversation.systemContext.channelId, subset)
-                        .also { result ->
-                            log.debug("Caching routing information: {}", result)
-                            lmosRuntimeTenantAwareCache.save(
-                                tenantId,
-                                ROUTES,
-                                conversationId,
-                                result,
-                                lmosRuntimeConfig.cache.ttl,
-                            )
-                        }
+            val cachedRoutingInformation = lmosRuntimeTenantAwareCache.get(tenantId, ROUTES, conversationId)
+            val routingInformation = if (subset != null && cachedRoutingInformation?.subset != subset) {
+                // If a different subset is provided, fetch new routing information
+                agentRegistryService
+                    .getRoutingInformation(tenantId, conversation.systemContext.channelId, subset)
+                    .also { result ->
+                        log.debug("Caching routing information with new subset: {}", result)
+                        lmosRuntimeTenantAwareCache.save(
+                            tenantId,
+                            ROUTES,
+                            conversationId,
+                            result,
+                            lmosRuntimeConfig.cache.ttl,
+                        )
+                    }
+            } else {
+                cachedRoutingInformation ?: agentRegistryService
+                    .getRoutingInformation(tenantId, conversation.systemContext.channelId, subset)
+                    .also { result ->
+                        log.debug("Caching routing information: {}", result)
+                        lmosRuntimeTenantAwareCache.save(
+                            tenantId,
+                            ROUTES,
+                            conversationId,
+                            result,
+                            lmosRuntimeConfig.cache.ttl,
+                        )
+                    }
+            }
             log.info("routingInformation: $routingInformation")
             val agent: Agent = agentRoutingService.resolveAgentForConversation(conversation, routingInformation.agentList)
             log.info("Resolved agent: $agent")

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandler.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandler.kt
@@ -50,34 +50,35 @@ class DefaultConversationHandler(
         coroutineScope {
             log.debug("Request Received, conversationId: $conversationId, turnId: $turnId")
             val cachedRoutingInformation = lmosRuntimeTenantAwareCache.get(tenantId, ROUTES, conversationId)
-            val routingInformation = if (subset != null && cachedRoutingInformation?.subset != subset) {
-                // If a different subset is provided, fetch new routing information
-                agentRegistryService
-                    .getRoutingInformation(tenantId, conversation.systemContext.channelId, subset)
-                    .also { result ->
-                        log.debug("Caching routing information with new subset: {}", result)
-                        lmosRuntimeTenantAwareCache.save(
-                            tenantId,
-                            ROUTES,
-                            conversationId,
-                            result,
-                            lmosRuntimeConfig.cache.ttl,
-                        )
-                    }
-            } else {
-                cachedRoutingInformation ?: agentRegistryService
-                    .getRoutingInformation(tenantId, conversation.systemContext.channelId, subset)
-                    .also { result ->
-                        log.debug("Caching routing information: {}", result)
-                        lmosRuntimeTenantAwareCache.save(
-                            tenantId,
-                            ROUTES,
-                            conversationId,
-                            result,
-                            lmosRuntimeConfig.cache.ttl,
-                        )
-                    }
-            }
+            val routingInformation =
+                if (subset != null && cachedRoutingInformation?.subset != subset) {
+                    // If a different subset is provided, fetch new routing information
+                    agentRegistryService
+                        .getRoutingInformation(tenantId, conversation.systemContext.channelId, subset)
+                        .also { result ->
+                            log.debug("Caching routing information with new subset: {}", result)
+                            lmosRuntimeTenantAwareCache.save(
+                                tenantId,
+                                ROUTES,
+                                conversationId,
+                                result,
+                                lmosRuntimeConfig.cache.ttl,
+                            )
+                        }
+                } else {
+                    cachedRoutingInformation ?: agentRegistryService
+                        .getRoutingInformation(tenantId, conversation.systemContext.channelId, subset)
+                        .also { result ->
+                            log.debug("Caching routing information: {}", result)
+                            lmosRuntimeTenantAwareCache.save(
+                                tenantId,
+                                ROUTES,
+                                conversationId,
+                                result,
+                                lmosRuntimeConfig.cache.ttl,
+                            )
+                        }
+                }
             log.info("routingInformation: $routingInformation")
             val agent: Agent = agentRoutingService.resolveAgentForConversation(conversation, routingInformation.agentList)
             log.info("Resolved agent: $agent")

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/service/outbound/AgentRegistryService.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/service/outbound/AgentRegistryService.kt
@@ -12,5 +12,6 @@ interface AgentRegistryService {
     suspend fun getRoutingInformation(
         tenantId: String,
         channelId: String,
+        subset: String? = null,
     ): RoutingInformation
 }

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/outbound/LmosOperatorAgentRegistry.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/outbound/LmosOperatorAgentRegistry.kt
@@ -55,6 +55,7 @@ class LmosOperatorAgentRegistry(
     override suspend fun getRoutingInformation(
         tenantId: String,
         channelId: String,
+        subset: String?,
     ): RoutingInformation {
         val urlString =
             "${lmosRuntimeConfig.agentRegistry.baseUrl}/apis/v1/tenants/$tenantId/channels/$channelId/routing"
@@ -62,7 +63,9 @@ class LmosOperatorAgentRegistry(
 
         val response =
             try {
-                client.get(urlString)
+                client.get(urlString) {
+                    subset?.let { headers.append(SUBSET, it) }
+                }
             } catch (e: Exception) {
                 log.error("Exception from Operator with url $urlString is $e")
                 throw InternalServerErrorException("Operator responded with an error")

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/outbound/LmosOperatorAgentRegistry.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/outbound/LmosOperatorAgentRegistry.kt
@@ -59,7 +59,7 @@ class LmosOperatorAgentRegistry(
     ): RoutingInformation {
         val urlString =
             "${lmosRuntimeConfig.agentRegistry.baseUrl}/apis/v1/tenants/$tenantId/channels/$channelId/routing"
-        log.trace("Calling operator: $urlString")
+        log.trace("Calling operator: $urlString with subset: $subset")
 
         val response =
             try {

--- a/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandlerIntegrationTest.kt
+++ b/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandlerIntegrationTest.kt
@@ -99,13 +99,14 @@ class ConversationHandlerIntegrationTest : BaseWireMockTest() {
             val spyAgentRegistryService = spyk(agentRegistryService)
 
             // Create a new conversation handler with the spy
-            val handlerWithSpy = DefaultConversationHandler(
-                spyAgentRegistryService,
-                agentRoutingService,
-                agentClientService,
-                lmosRuntimeConfig,
-                lmosRuntimeTenantAwareCache
-            )
+            val handlerWithSpy =
+                DefaultConversationHandler(
+                    spyAgentRegistryService,
+                    agentRoutingService,
+                    agentClientService,
+                    lmosRuntimeConfig,
+                    lmosRuntimeTenantAwareCache,
+                )
 
             val assistantMessage =
                 handlerWithSpy.handleConversation(conversation, conversationId, tenantId, turnId, subset).first()
@@ -113,8 +114,8 @@ class ConversationHandlerIntegrationTest : BaseWireMockTest() {
             assertEquals("Response with subset", assistantMessage.content)
 
             // Verify that the subset parameter was passed to the agent registry service
-            coVerify(exactly = 1) { 
-                spyAgentRegistryService.getRoutingInformation(tenantId, conversation.systemContext.channelId, subset) 
+            coVerify(exactly = 1) {
+                spyAgentRegistryService.getRoutingInformation(tenantId, conversation.systemContext.channelId, subset)
             }
         }
 

--- a/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandlerTest.kt
+++ b/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandlerTest.kt
@@ -88,8 +88,8 @@ class ConversationHandlerTest {
             assertEquals(agentResponse, result)
 
             // Verify that getRoutingInformation was called with null subset
-            coVerify(exactly = 1) { 
-                agentRegistryService.getRoutingInformation(tenantId, conversation.systemContext.channelId, null) 
+            coVerify(exactly = 1) {
+                agentRegistryService.getRoutingInformation(tenantId, conversation.systemContext.channelId, null)
             }
         }
 
@@ -125,8 +125,8 @@ class ConversationHandlerTest {
             assertEquals(agentResponse, result)
 
             // Verify that getRoutingInformation was called with the correct subset
-            coVerify(exactly = 1) { 
-                agentRegistryService.getRoutingInformation(tenantId, conversation.systemContext.channelId, subset) 
+            coVerify(exactly = 1) {
+                agentRegistryService.getRoutingInformation(tenantId, conversation.systemContext.channelId, subset)
             }
         }
 
@@ -270,8 +270,8 @@ class ConversationHandlerTest {
             }
 
             // Verify that getRoutingInformation was not called
-            coVerify(exactly = 0) { 
-                agentRegistryService.getRoutingInformation(any(), any(), any()) 
+            coVerify(exactly = 0) {
+                agentRegistryService.getRoutingInformation(any(), any(), any())
             }
         }
 
@@ -322,8 +322,8 @@ class ConversationHandlerTest {
             assertEquals(expectedAgentResponse, result)
 
             // Verify that getRoutingInformation was called with the new subset
-            coVerify(exactly = 1) { 
-                agentRegistryService.getRoutingInformation(tenantId, conversation.systemContext.channelId, newSubset) 
+            coVerify(exactly = 1) {
+                agentRegistryService.getRoutingInformation(tenantId, conversation.systemContext.channelId, newSubset)
             }
 
             // Verify that the new routing information was cached

--- a/lmos-runtime-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/runtime/inbound/LmosRuntimeAutoConfigurationCustomBeansTest.kt
+++ b/lmos-runtime-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/runtime/inbound/LmosRuntimeAutoConfigurationCustomBeansTest.kt
@@ -102,6 +102,7 @@ class LmosRuntimeAutoConfigurationCustomBeansTest {
                 override suspend fun getRoutingInformation(
                     tenantId: String,
                     channelId: String,
+                    subset: String?
                 ): RoutingInformation {
                     TODO("Not yet implemented")
                 }
@@ -154,6 +155,7 @@ class LmosRuntimeAutoConfigurationCustomBeansTest {
                     conversationId: String,
                     tenantId: String,
                     turnId: String,
+                    subset: String?
                 ): Flow<AssistantMessage> {
                     TODO("Not yet implemented")
                 }

--- a/lmos-runtime-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/runtime/inbound/LmosRuntimeAutoConfigurationCustomBeansTest.kt
+++ b/lmos-runtime-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/runtime/inbound/LmosRuntimeAutoConfigurationCustomBeansTest.kt
@@ -102,7 +102,7 @@ class LmosRuntimeAutoConfigurationCustomBeansTest {
                 override suspend fun getRoutingInformation(
                     tenantId: String,
                     channelId: String,
-                    subset: String?
+                    subset: String?,
                 ): RoutingInformation {
                     TODO("Not yet implemented")
                 }
@@ -155,7 +155,7 @@ class LmosRuntimeAutoConfigurationCustomBeansTest {
                     conversationId: String,
                     tenantId: String,
                     turnId: String,
-                    subset: String?
+                    subset: String?,
                 ): Flow<AssistantMessage> {
                     TODO("Not yet implemented")
                 }


### PR DESCRIPTION
This commit adds support for passing a subset parameter from the ConversationHandler to the LmosOperatorAgentRegistry API call as an "x-subset" header.