### PR TITLE
feat: Implement FileBasedAgentRegistryService

### DIFF
--- a/lmos-runtime-core/build.gradle.kts
+++ b/lmos-runtime-core/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
     implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:$kotlinxSerializationVersion")
+    implementation("com.charleskorn.kaml:kaml:0.55.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.10.1")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.3")
     implementation("org.slf4j:slf4j-api:2.0.17")
@@ -28,7 +29,9 @@ dependencies {
     api("org.eclipse.lmos:arc-agent-client:$arcVersion")
     api("org.eclipse.lmos:arc-api:$arcVersion")
 
+    testImplementation(kotlin("test-junit5"))
     testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
 
     testFixturesImplementation("com.marcinziolo:kotlin-wiremock:2.1.1")
     testFixturesImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/AgentRegistryType.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/AgentRegistryType.kt
@@ -1,0 +1,12 @@
+/*
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+ * //
+ * // SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.lmos.runtime.core
+
+enum class AgentRegistryType {
+    API,
+    FILE,
+}

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/LmosRuntimeConfig.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/LmosRuntimeConfig.kt
@@ -12,7 +12,9 @@ open class LmosRuntimeConfig(
     val cache: Cache,
 ) {
     data class AgentRegistry(
-        val baseUrl: String,
+        val baseUrl: String? = null, // Made nullable
+        val type: AgentRegistryType = AgentRegistryType.API, // Default to API
+        val filePath: String? = null, // Path to the YAML file
     )
 
     data class OpenAI(

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandler.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandler.kt
@@ -15,10 +15,10 @@ import org.eclipse.lmos.runtime.core.constants.LmosRuntimeConstants.Cache.ROUTES
 import org.eclipse.lmos.runtime.core.model.Agent
 import org.eclipse.lmos.runtime.core.model.AssistantMessage
 import org.eclipse.lmos.runtime.core.model.Conversation
+import org.eclipse.lmos.runtime.core.model.registry.RoutingInformation
 import org.eclipse.lmos.runtime.core.service.outbound.AgentClientService
 import org.eclipse.lmos.runtime.core.service.outbound.AgentRegistryService
 import org.eclipse.lmos.runtime.core.service.outbound.AgentRoutingService
-import org.eclipse.lmos.runtime.outbound.RoutingInformation
 import org.slf4j.LoggerFactory
 
 interface ConversationHandler {

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/model/registry/AgentRegistryDocument.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/model/registry/AgentRegistryDocument.kt
@@ -1,0 +1,14 @@
+/*
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+ * //
+ * // SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.lmos.runtime.core.model.registry
+
+import kotlinx.serialization.Serializable // Or Jackson if that's standard
+
+@Serializable // Or Jackson annotations
+data class AgentRegistryDocument(
+    val channelRoutings: List<ChannelRouting>,
+)

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/model/registry/RegistryModels.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/model/registry/RegistryModels.kt
@@ -1,0 +1,90 @@
+/*
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+ * //
+ * // SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.lmos.runtime.core.model.registry
+
+import kotlinx.serialization.Serializable
+import org.eclipse.lmos.runtime.core.model.Address
+import org.eclipse.lmos.runtime.core.model.Agent
+import org.eclipse.lmos.runtime.core.model.AgentBuilder
+import org.eclipse.lmos.runtime.core.model.AgentCapability
+
+@Serializable
+data class ChannelRouting(
+    val apiVersion: String? = null, // Made nullable
+    val kind: String? = null, // Made nullable
+    val metadata: Metadata,
+    val spec: Spec,
+    val subset: String? = null,
+)
+
+@Serializable
+data class Metadata(
+    val name: String,
+    val namespace: String,
+    val labels: Labels,
+    val creationTimestamp: String? = null,
+    val generation: Int? = null,
+    val resourceVersion: String? = null,
+    val uid: String? = null,
+)
+
+@Serializable
+data class Labels(
+    val channel: String,
+    val subset: String? = null,
+    val tenant: String,
+    val version: String,
+)
+
+@Serializable
+data class Spec(
+    val capabilityGroups: List<CapabilityGroup>,
+)
+
+@Serializable
+data class CapabilityGroup(
+    val name: String,
+    val description: String,
+    val capabilities: List<Capability>,
+)
+
+@Serializable
+data class Capability(
+    val name: String,
+    val providedVersion: String,
+    val description: String,
+    val host: String,
+    val requiredVersion: String? = null,
+)
+
+data class RoutingInformation(
+    val agentList: List<Agent>,
+    val subset: String?,
+)
+
+fun ChannelRouting.toAgent(): List<Agent> {
+    val agentVersion = this.metadata.labels.version
+    return this.spec.capabilityGroups
+        .map { agent ->
+            AgentBuilder()
+                .name(agent.name)
+                .description(agent.description)
+                .version(agentVersion)
+                .apply {
+                    agent.capabilities.firstOrNull()?.let { addAddress(Address(uri = it.host)) }
+                    agent.capabilities.forEach { capability ->
+                        addCapability(
+                            AgentCapability(
+                                name = capability.name,
+                                version = capability.providedVersion,
+                                description = capability.description,
+                            ),
+                        )
+                    }
+                }.build()
+        }.toList()
+}

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/service/outbound/AgentRegistryService.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/service/outbound/AgentRegistryService.kt
@@ -6,7 +6,7 @@
 
 package org.eclipse.lmos.runtime.core.service.outbound
 
-import org.eclipse.lmos.runtime.outbound.RoutingInformation
+import org.eclipse.lmos.runtime.core.model.registry.RoutingInformation
 
 interface AgentRegistryService {
     suspend fun getRoutingInformation(

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/service/outbound/FileBasedAgentRegistryService.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/service/outbound/FileBasedAgentRegistryService.kt
@@ -1,0 +1,83 @@
+/*
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+ * //
+ * // SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.lmos.runtime.core.service.outbound
+
+import com.charleskorn.kaml.Yaml
+import org.eclipse.lmos.runtime.core.exception.NoRoutingInfoFoundException
+import org.eclipse.lmos.runtime.core.model.registry.AgentRegistryDocument
+import org.eclipse.lmos.runtime.core.model.registry.RoutingInformation
+import org.eclipse.lmos.runtime.core.model.registry.toAgent
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.io.FileNotFoundException
+
+class FileBasedAgentRegistryService(
+    private val filePath: String,
+) : AgentRegistryService {
+    private val log = LoggerFactory.getLogger(FileBasedAgentRegistryService::class.java)
+    private val agentRegistryDocument: AgentRegistryDocument
+
+    init {
+        log.info("Initializing FileBasedAgentRegistryService with file: \$filePath")
+        try {
+            val yamlContent = File(filePath).readText()
+            // If using kaml (kotlinx-serialization-yaml)
+            agentRegistryDocument = Yaml.default.decodeFromString(AgentRegistryDocument.serializer(), yamlContent)
+            // If using Jackson:
+            // val mapper = ObjectMapper(YAMLFactory()).registerModule(KotlinModule())
+            // agentRegistryDocument = mapper.readValue(yamlContent, AgentRegistryDocument::class.java)
+            log.info("Successfully loaded and parsed agent registry file: \$filePath")
+        } catch (e: FileNotFoundException) {
+            log.error("Agent registry file not found at path: \$filePath", e)
+            throw IllegalArgumentException("Agent registry file not found: \$filePath", e)
+        } catch (e: Exception) {
+            // Catching general exception for parsing errors
+            log.error("Error parsing agent registry file: \$filePath", e)
+            throw IllegalArgumentException("Error parsing agent registry file: \$filePath. Details: \${e.message}", e)
+        }
+    }
+
+    override suspend fun getRoutingInformation(
+        tenantId: String,
+        channelId: String,
+        subset: String?,
+    ): RoutingInformation {
+        val effectiveSubset = subset ?: "any"
+        log.debug(
+            "Searching for routing information for tenant: $tenantId, channel: $channelId, subset: $effectiveSubset",
+        )
+
+        val matchingChannelRouting =
+            agentRegistryDocument.channelRoutings.find { cr ->
+                val labels = cr.metadata.labels
+                val tenantMatch = labels.tenant == tenantId
+                val channelMatch = labels.channel == channelId
+                // If requested subset is null, match only if label's subset is also null.
+                // If requested subset is non-null, match only if label's subset is equal.
+                val subsetMatch = labels.subset == subset
+                tenantMatch && channelMatch && subsetMatch
+            }
+
+        if (matchingChannelRouting == null) {
+            log.warn(
+                "No routing information found for tenant: $tenantId, channel: $channelId, subset: $effectiveSubset",
+            )
+            throw NoRoutingInfoFoundException(
+                "No routing information found in file for tenant: $tenantId, channel: $channelId, subset: $effectiveSubset",
+            )
+        }
+
+        log.info(
+            "Found routing information for tenant: $tenantId, channel: $channelId, subset: $effectiveSubset: ${matchingChannelRouting.metadata.name}",
+        )
+        // Use the existing toAgent() extension function and RoutingInformation data class
+        return RoutingInformation(
+            agentList = matchingChannelRouting.toAgent(), // toAgent() is now on ChannelRouting
+            subset = matchingChannelRouting.metadata.labels.subset, // Or from the request 'subset' if preferred
+        )
+    }
+}

--- a/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandlerIntegrationTest.kt
+++ b/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandlerIntegrationTest.kt
@@ -20,10 +20,10 @@ import org.eclipse.lmos.runtime.core.exception.AgentClientException
 import org.eclipse.lmos.runtime.core.exception.AgentNotFoundException
 import org.eclipse.lmos.runtime.core.exception.NoRoutingInfoFoundException
 import org.eclipse.lmos.runtime.core.model.*
+import org.eclipse.lmos.runtime.core.model.registry.RoutingInformation
 import org.eclipse.lmos.runtime.core.service.routing.ExplicitAgentRoutingService
 import org.eclipse.lmos.runtime.outbound.ArcAgentClientService
 import org.eclipse.lmos.runtime.outbound.LmosOperatorAgentRegistry
-import org.eclipse.lmos.runtime.outbound.RoutingInformation
 import org.eclipse.lmos.runtime.test.BaseWireMockTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows

--- a/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandlerTest.kt
+++ b/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandlerTest.kt
@@ -17,11 +17,11 @@ import org.eclipse.lmos.runtime.core.constants.LmosRuntimeConstants.Cache.ROUTES
 import org.eclipse.lmos.runtime.core.exception.AgentClientException
 import org.eclipse.lmos.runtime.core.exception.NoRoutingInfoFoundException
 import org.eclipse.lmos.runtime.core.model.*
+import org.eclipse.lmos.runtime.core.model.registry.RoutingInformation
 import org.eclipse.lmos.runtime.core.service.outbound.AgentClientService
 import org.eclipse.lmos.runtime.core.service.outbound.AgentRegistryService
 import org.eclipse.lmos.runtime.core.service.outbound.AgentRoutingService
 import org.eclipse.lmos.runtime.core.service.routing.ExplicitAgentRoutingService
-import org.eclipse.lmos.runtime.outbound.RoutingInformation
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows

--- a/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/service/outbound/FileBasedAgentRegistryServiceTest.kt
+++ b/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/service/outbound/FileBasedAgentRegistryServiceTest.kt
@@ -1,0 +1,133 @@
+/*
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+ * //
+ * // SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.lmos.runtime.core.service.outbound
+
+import kotlinx.coroutines.runBlocking
+import org.eclipse.lmos.runtime.core.exception.NoRoutingInfoFoundException
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class FileBasedAgentRegistryServiceTest {
+    private fun getTestResourcePath(fileName: String): String =
+        FileBasedAgentRegistryServiceTest::class.java.classLoader
+            .getResource(fileName)
+            ?.path
+            ?: throw IllegalStateException("Test resource \$fileName not found.")
+
+    @Test
+    fun `should load and parse valid YAML and find routing information`() =
+        runBlocking {
+            val service = FileBasedAgentRegistryService(getTestResourcePath("test-agent-registry.yaml"))
+            val routingInfo = service.getRoutingInformation("acme", "web", "stable")
+
+            assertNotNull(routingInfo)
+            assertEquals(1, routingInfo.agentList.size)
+            assertEquals("contract-agent", routingInfo.agentList[0].name)
+            assertEquals("stable", routingInfo.subset)
+        }
+
+    @Test
+    fun `should find routing information when no subset is requested and a generic match exists`() =
+        runBlocking {
+            // This test assumes that if a specific subset is not found or not requested,
+            // a match with no subset label is considered.
+            // The current implementation requires subset to be null in labels for this.
+            val service = FileBasedAgentRegistryService(getTestResourcePath("test-agent-registry.yaml"))
+            val routingInfo = service.getRoutingInformation("acme", "web", null) // Requesting without subset
+
+            assertNotNull(routingInfo)
+            assertEquals(1, routingInfo.agentList.size)
+            assertEquals("contract-agent-generic", routingInfo.agentList[0].name)
+            // The routingInfo.subset should reflect the subset from the matched label, which is null in this case.
+            assertNull(routingInfo.subset)
+        }
+
+    @Test
+    fun `should find routing information for different tenant and channel`() =
+        runBlocking {
+            val service = FileBasedAgentRegistryService(getTestResourcePath("test-agent-registry.yaml"))
+            val routingInfo = service.getRoutingInformation("another-tenant", "app", "beta")
+
+            assertNotNull(routingInfo)
+            assertEquals(1, routingInfo.agentList.size)
+            assertEquals("beta-feature-agent", routingInfo.agentList[0].name)
+            assertEquals("beta", routingInfo.subset)
+        }
+
+    @Test
+    fun `should throw NoRoutingInfoFoundException when no match found`() =
+        runBlocking {
+            val service = FileBasedAgentRegistryService(getTestResourcePath("test-agent-registry.yaml"))
+
+            assertThrows(NoRoutingInfoFoundException::class.java) {
+                runBlocking { service.getRoutingInformation("nonexistent", "channel", null) }
+            }
+        }
+
+    @Test
+    fun `should throw NoRoutingInfoFoundException when subset does not match`() =
+        runBlocking {
+            val service = FileBasedAgentRegistryService(getTestResourcePath("test-agent-registry.yaml"))
+
+            assertThrows(NoRoutingInfoFoundException::class.java) {
+                runBlocking { service.getRoutingInformation("acme", "web", "nonexistent-subset") }
+            }
+        }
+
+    @Test
+    fun `should throw IllegalArgumentException for non-existent file`() {
+        val exception =
+            assertThrows(IllegalArgumentException::class.java) {
+                FileBasedAgentRegistryService("non-existent-file.yaml")
+            }
+        assertTrue(exception.message?.contains("Agent registry file not found") == true)
+    }
+
+    @Test
+    fun `should throw IllegalArgumentException for malformed YAML`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val malformedFile = tempDir.resolve("malformed.yaml").toFile()
+        malformedFile.writeText("channelRoutings: - metadata: name: broken") // Invalid YAML structure
+
+        val exception =
+            assertThrows(IllegalArgumentException::class.java) {
+                FileBasedAgentRegistryService(malformedFile.absolutePath)
+            }
+        assertTrue(exception.message?.contains("Error parsing agent registry file") == true)
+    }
+
+    @Test
+    fun `should handle empty channelRoutings list`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val emptyRegistryFile = tempDir.resolve("empty.yaml").toFile()
+        emptyRegistryFile.writeText("channelRoutings: []")
+
+        val service = FileBasedAgentRegistryService(emptyRegistryFile.absolutePath)
+        assertThrows(NoRoutingInfoFoundException::class.java) {
+            runBlocking { service.getRoutingInformation("acme", "web", "stable") }
+        }
+    }
+
+    @Test
+    fun `should handle completely empty YAML file`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val emptyFile = tempDir.resolve("completely-empty.yaml").toFile()
+        emptyFile.writeText("") // Empty content
+
+        // Kaml might throw an exception if it can't deserialize to AgentRegistryDocument (e.g. "channelRoutings" is missing)
+        val exception =
+            assertThrows(IllegalArgumentException::class.java) {
+                FileBasedAgentRegistryService(emptyFile.absolutePath)
+            }
+        assertTrue(exception.message?.contains("Error parsing agent registry file") == true)
+    }
+}

--- a/lmos-runtime-core/src/test/resources/test-agent-registry.yaml
+++ b/lmos-runtime-core/src/test/resources/test-agent-registry.yaml
@@ -1,0 +1,59 @@
+#
+# // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+# //
+# // SPDX-License-Identifier: Apache-2.0
+#
+
+channelRoutings:
+  - metadata:
+      name: "acme-web-stable"
+      namespace: "test"
+      labels:
+        version: "1.0.0"
+        tenant: "acme"
+        channel: "web"
+        subset: "stable"
+    spec:
+      capabilityGroups:
+        - name: "contract-agent"
+          description: "Contract agent for acme-web-stable"
+          capabilities:
+            - name: "view-contract"
+              providedVersion: "1.1.0"
+              description: "View a contract"
+              host: "contract-agent-stable-svc"
+  - metadata:
+      name: "acme-web-generic"
+      namespace: "test"
+      labels:
+        version: "1.0.1"
+        tenant: "acme"
+        channel: "web"
+        # No subset specified, should match if no subset is requested or if it's a fallback
+      # Ensure subset is nullable in Labels or handled if missing
+    spec:
+      capabilityGroups:
+        - name: "contract-agent-generic"
+          description: "Generic Contract agent for acme-web"
+          capabilities:
+            - name: "view-contract"
+              providedVersion: "1.0.0"
+              description: "View a contract (generic)"
+              host: "contract-agent-generic-svc"
+  - metadata:
+      name: "another-tenant-app-beta"
+      namespace: "test"
+      labels:
+        version: "2.0.0"
+        tenant: "another-tenant"
+        channel: "app"
+        subset: "beta"
+    spec:
+      capabilityGroups:
+        - name: "beta-feature-agent"
+          description: "Beta agent for another-tenant"
+          capabilities:
+            - name: "test-feature"
+              providedVersion: "2.0.0"
+              description: "Test a new feature"
+              host: "beta-agent-svc"

--- a/lmos-runtime-spring-boot-starter/build.gradle.kts
+++ b/lmos-runtime-spring-boot-starter/build.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.10.1")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
 }

--- a/lmos-runtime-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/runtime/config/ApiAgentRegistryLoadedConditionTest.kt
+++ b/lmos-runtime-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/runtime/config/ApiAgentRegistryLoadedConditionTest.kt
@@ -1,0 +1,38 @@
+/*
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+ * //
+ * // SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.lmos.runtime.config
+
+import org.eclipse.lmos.runtime.core.service.outbound.AgentRegistryService
+import org.eclipse.lmos.runtime.outbound.LmosOperatorAgentRegistry
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.test.context.TestPropertySource
+
+@SpringBootTest(classes = [LmosRuntimeAutoConfiguration::class])
+@TestPropertySource(
+    properties = [
+        "lmos.runtime.agent-registry.type=API",
+        "lmos.runtime.agent-registry.base-url=http://dummy-api.com",
+        "lmos.runtime.cache.ttl=600",
+        "lmos.runtime.router.type=EXPLICIT", // Added router type
+    ],
+)
+class ApiAgentRegistryLoadedConditionTest {
+    @Autowired
+    private lateinit var context: ApplicationContext
+
+    @Test
+    fun `should load LmosOperatorAgentRegistry when type is API`() {
+        val agentRegistryService = context.getBean(AgentRegistryService::class.java)
+        assertNotNull(agentRegistryService)
+        assertInstanceOf(LmosOperatorAgentRegistry::class.java, agentRegistryService)
+    }
+}

--- a/lmos-runtime-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/runtime/config/FileAgentRegistryLoadedConditionTest.kt
+++ b/lmos-runtime-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/runtime/config/FileAgentRegistryLoadedConditionTest.kt
@@ -1,0 +1,38 @@
+/*
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+ * //
+ * // SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.lmos.runtime.config
+
+import org.eclipse.lmos.runtime.core.service.outbound.AgentRegistryService
+import org.eclipse.lmos.runtime.core.service.outbound.FileBasedAgentRegistryService
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.test.context.TestPropertySource
+
+@SpringBootTest(classes = [LmosRuntimeAutoConfiguration::class])
+@TestPropertySource(
+    properties = [
+        "lmos.runtime.agent-registry.type=FILE",
+        "lmos.runtime.agent-registry.file-path=src/test/resources/integration-test-agent-registry.yaml",
+        "lmos.runtime.cache.ttl=600",
+        "lmos.runtime.router.type=EXPLICIT", // Added router type
+    ],
+)
+class FileAgentRegistryLoadedConditionTest {
+    @Autowired
+    private lateinit var context: ApplicationContext
+
+    @Test
+    fun `should load FileBasedAgentRegistryService when type is FILE`() {
+        val agentRegistryService = context.getBean(AgentRegistryService::class.java)
+        assertNotNull(agentRegistryService)
+        assertInstanceOf(FileBasedAgentRegistryService::class.java, agentRegistryService)
+    }
+}

--- a/lmos-runtime-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/runtime/config/FileBasedAgentRegistryIntegrationTest.kt
+++ b/lmos-runtime-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/runtime/config/FileBasedAgentRegistryIntegrationTest.kt
@@ -1,0 +1,61 @@
+/*
+ * // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+ * //
+ * // SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.lmos.runtime.config
+
+import kotlinx.coroutines.runBlocking
+import org.eclipse.lmos.runtime.core.exception.NoRoutingInfoFoundException
+import org.eclipse.lmos.runtime.core.service.outbound.AgentRegistryService
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestPropertySource
+
+@SpringBootTest(classes = [LmosRuntimeAutoConfiguration::class]) // Minimal context
+@TestPropertySource(
+    properties = [
+        "lmos.runtime.agent-registry.type=FILE",
+        "lmos.runtime.agent-registry.file-path=src/test/resources/integration-test-agent-registry.yaml",
+        "lmos.runtime.router.type=EXPLICIT",
+        "lmos.runtime.cache.ttl=600",
+    ],
+)
+class FileBasedAgentRegistryIntegrationTest {
+    @Autowired
+    private lateinit var agentRegistryService: AgentRegistryService
+
+    // If ConversationHandler is too complex to set up, test AgentRegistryService directly
+    // @Autowired
+    // private lateinit var conversationHandler: ConversationHandler
+
+    @Test
+    fun `should retrieve routing information using FileBasedAgentRegistryService via Spring context`() =
+        runBlocking {
+            val routingInfo = agentRegistryService.getRoutingInformation("integ-acme", "web", "stable")
+            assertNotNull(routingInfo)
+            assertEquals(1, routingInfo.agentList.size)
+            assertEquals("integ-contract-agent", routingInfo.agentList[0].name)
+            assertEquals("stable", routingInfo.subset)
+
+            // Test a case without subset
+            val routingInfoNoSubset = agentRegistryService.getRoutingInformation("integ-acme", "app", null)
+            assertNotNull(routingInfoNoSubset)
+            assertEquals(1, routingInfoNoSubset.agentList.size)
+            assertEquals("integ-app-agent", routingInfoNoSubset.agentList[0].name)
+            assertNull(routingInfoNoSubset.subset)
+        }
+
+    @Test
+    fun `should throw NoRoutingInfoFoundException for non-existent entry via Spring context`() =
+        runBlocking {
+            assertThrows(NoRoutingInfoFoundException::class.java) {
+                runBlocking {
+                    agentRegistryService.getRoutingInformation("non-existent", "channel", null)
+                }
+            }
+        }
+}

--- a/lmos-runtime-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/runtime/inbound/LmosRuntimeAutoConfigurationCustomBeansTest.kt
+++ b/lmos-runtime-spring-boot-starter/src/test/kotlin/org/eclipse/lmos/runtime/inbound/LmosRuntimeAutoConfigurationCustomBeansTest.kt
@@ -15,12 +15,12 @@ import org.eclipse.lmos.runtime.core.model.Address
 import org.eclipse.lmos.runtime.core.model.Agent
 import org.eclipse.lmos.runtime.core.model.AssistantMessage
 import org.eclipse.lmos.runtime.core.model.Conversation
+import org.eclipse.lmos.runtime.core.model.registry.RoutingInformation
 import org.eclipse.lmos.runtime.core.service.outbound.AgentClientService
 import org.eclipse.lmos.runtime.core.service.outbound.AgentRegistryService
 import org.eclipse.lmos.runtime.core.service.outbound.AgentRoutingService
 import org.eclipse.lmos.runtime.outbound.ArcAgentClientService
 import org.eclipse.lmos.runtime.outbound.LmosAgentRoutingService
-import org.eclipse.lmos.runtime.outbound.RoutingInformation
 import org.eclipse.lmos.runtime.properties.LmosRuntimeProperties
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test

--- a/lmos-runtime-spring-boot-starter/src/test/resources/integration-test-agent-registry.yaml
+++ b/lmos-runtime-spring-boot-starter/src/test/resources/integration-test-agent-registry.yaml
@@ -1,0 +1,40 @@
+#
+# // SPDX-FileCopyrightText: 2025 Deutsche Telekom AG and others
+# //
+# // SPDX-License-Identifier: Apache-2.0
+#
+channelRoutings:
+  - metadata:
+      name: "integ-acme-web-stable"
+      namespace: "integ-test"
+      labels:
+        version: "1.0.0"
+        tenant: "integ-acme"
+        channel: "web"
+        subset: "stable"
+    spec:
+      capabilityGroups:
+        - name: "integ-contract-agent"
+          description: "Contract agent for integ-acme-web-stable"
+          capabilities:
+            - name: "view-contract"
+              providedVersion: "1.1.0"
+              description: "View a contract"
+              host: "integ-contract-agent-stable-svc"
+  - metadata:
+      name: "integ-acme-app-generic"
+      namespace: "integ-test"
+      labels:
+        version: "1.0.1"
+        tenant: "integ-acme"
+        channel: "app"
+        # No subset for this one
+    spec:
+      capabilityGroups:
+        - name: "integ-app-agent"
+          description: "App agent for integ-acme"
+          capabilities:
+            - name: "view-profile"
+              providedVersion: "1.0.0"
+              description: "View user profile"
+              host: "integ-app-agent-svc"


### PR DESCRIPTION
This commit introduces a new implementation of AgentRegistryService, `FileBasedAgentRegistryService`, which reads agent routing information from a YAML file.

Key changes:
- Added `FileBasedAgentRegistryService` in `lmos-runtime-core` that parses an `agent-registry.yaml` file.
- Introduced configuration properties in `lmos-runtime-spring-boot-starter` to switch between `API` and `FILE` based registry types (lmos.runtime.agent-registry.type) and to specify the YAML file path (lmos.runtime.agent-registry.file-path).
- Updated `LmosRuntimeAutoConfiguration` to conditionally instantiate the configured `AgentRegistryService` implementation.
- Refactored agent registry data models to a common location in `lmos-runtime-core.model.registry` and made necessary adjustments for YAML deserialization (e.g., nullable fields).
- Added `kaml` library for YAML parsing in `lmos-runtime-core`.
- Implemented comprehensive unit tests for `FileBasedAgentRegistryService` in `lmos-runtime-core`.
- Implemented integration tests in `lmos-runtime-spring-boot-starter` to verify the correct service instantiation and functionality within the Spring context.

The choice of `AgentRegistryService` is now configurable via properties:
- `lmos.runtime.agent-registry.type`: Set to `FILE` to use the new service, or `API` (default) for the existing LMOS Operator based service.
- `lmos.runtime.agent-registry.file-path`: Specifies the path to the `agent-registry.yaml` file when type is `FILE`.

The `lmos-runtime-core` and `lmos-runtime-spring-boot-starter` modules build and pass all their tests. An unrelated issue with Helm setup was noted in the `lmos-runtime-graphql-service` module but does not affect this feature.