### PR TITLE
chore: activate classifier only when at least one classifier is enabled via configuration instead of activation by feature keys.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.lang.System.getenv
 import java.net.URI
 
@@ -58,13 +57,12 @@ subprojects {
 
         kotlin {
             compilerOptions {
-                freeCompilerArgs = listOf("-Xjsr305=strict", "-Xcontext-receivers")
-                jvmTarget = JvmTarget.JVM_25
+                freeCompilerArgs.add("-Xcontext-receivers")
             }
         }
         java {
             toolchain {
-                languageVersion = JavaLanguageVersion.of(25)
+                languageVersion = JavaLanguageVersion.of(21)
             }
         }
 

--- a/lmos-runtime-bom/build.gradle.kts
+++ b/lmos-runtime-bom/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     val ktorVersion = "3.4.0"
     val kotlinxVersion = "1.10.0"
     val lmosRouterVersion = "0.24.0"
-    val arcVersion = "0.215.0"
+    val arcVersion = "0.216.0"
     val langChain4jVersion = "1.11.0"
     val kotlinCoroutines = "1.10.2"
 

--- a/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandler.kt
+++ b/lmos-runtime-core/src/main/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandler.kt
@@ -21,9 +21,6 @@ import org.eclipse.lmos.runtime.core.service.outbound.AgentClientService
 import org.eclipse.lmos.runtime.core.service.outbound.AgentRoutingService
 import org.slf4j.LoggerFactory
 
-const val ACTIVE_FEATURES_KEY = "activeFeatures"
-const val ACTIVE_FEATURE_KEY_CLASSIFIER = "classifier"
-
 interface ConversationHandler {
     suspend fun handleConversation(
         conversation: Conversation,
@@ -36,7 +33,7 @@ interface ConversationHandler {
 
 class DefaultConversationHandler(
     private val agentRoutingService: AgentRoutingService,
-    private val agentClassifierService: AgentClassifierService,
+    private val agentClassifierService: AgentClassifierService?,
     private val cachedChannelRoutingRepository: CachedChannelRoutingRepository,
     private val agentClientService: AgentClientService,
     private val disambiguationHandler: DisambiguationHandler?,
@@ -68,7 +65,7 @@ class DefaultConversationHandler(
             val agentName: String
             val agentAddress: Address
 
-            if (useClassifier(conversation)) {
+            if (agentClassifierService != null) {
                 log.info("Classifier feature is active, using new classifier for agent routing")
                 val classificationResult =
                     agentClassifierService.classify(
@@ -108,10 +105,4 @@ class DefaultConversationHandler(
                     routingInformation.subset,
                 )
         }
-
-    private fun useClassifier(conversation: Conversation): Boolean {
-        val activeFeatures = conversation.systemContext.contextParams.firstOrNull { it.key == ACTIVE_FEATURES_KEY }
-        val useClassifier = activeFeatures?.value?.contains(ACTIVE_FEATURE_KEY_CLASSIFIER) == true
-        return useClassifier
-    }
 }

--- a/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandlerTest.kt
+++ b/lmos-runtime-core/src/test/kotlin/org/eclipse/lmos/runtime/core/inbound/ConversationHandlerTest.kt
@@ -45,7 +45,6 @@ class ConversationHandlerTest {
     fun setUp() {
         agentClientService = mockk<AgentClientService>()
         agentRoutingService = ExplicitAgentRoutingService()
-        agentClassifierService = mockk<AgentClassifierService>()
         channelRoutingRepository = mockk<CachedChannelRoutingRepository>()
         lmosRuntimeConfig =
             RuntimeConfiguration(
@@ -64,7 +63,7 @@ class ConversationHandlerTest {
         conversationHandler =
             DefaultConversationHandler(
                 agentRoutingService,
-                agentClassifierService,
+                null,
                 channelRoutingRepository,
                 agentClientService,
                 disambiguationHandler,
@@ -218,10 +217,11 @@ class ConversationHandlerTest {
     fun `disambiguation is executed when disambiguation is activated`() =
         runTest {
             // given
+            initWithClassifier()
             val conversationId = "conv-124"
             val tenantId = "de"
             val turnId = "turn-1"
-            val conversation = conversation(listOf(KeyValuePair(ACTIVE_FEATURES_KEY, ACTIVE_FEATURE_KEY_CLASSIFIER)))
+            val conversation = conversation()
             val expectedDisambiguationResult =
                 DisambiguationResult(
                     topics = listOf("myTopics"),
@@ -254,10 +254,11 @@ class ConversationHandlerTest {
     fun `AgentNotFoundException is thrown when disambiguation is deactivated`() =
         runTest {
             // given
+            initWithClassifier()
             val conversationId = "conv-124"
             val tenantId = "de"
             val turnId = "turn-1"
-            val conversation = conversation(listOf(KeyValuePair(ACTIVE_FEATURES_KEY, ACTIVE_FEATURE_KEY_CLASSIFIER)))
+            val conversation = conversation()
 
             mockAgentClassifierService(
                 conversationId,
@@ -331,5 +332,17 @@ class ConversationHandlerTest {
         disambiguationResult: DisambiguationResult,
     ) {
         coEvery { disambiguationHandler.disambiguate(tenantId, conversation, candidateAgents) } returns disambiguationResult
+    }
+
+    private fun initWithClassifier() {
+        agentClassifierService = mockk<AgentClassifierService>()
+        conversationHandler =
+            DefaultConversationHandler(
+                agentRoutingService,
+                agentClassifierService,
+                channelRoutingRepository,
+                agentClientService,
+                disambiguationHandler,
+            )
     }
 }

--- a/lmos-runtime-service/src/main/resources/application.yaml
+++ b/lmos-runtime-service/src/main/resources/application.yaml
@@ -41,7 +41,7 @@ lmos:
       llm:
         enabled: ${CLASSIFIER_LLM_ENABLED:false}
       hybrid-fast-track:
-        enabled: ${CLASSIFIER_HYBRID_FASTTRACK_ENABLED:true}
+        enabled: ${CLASSIFIER_HYBRID_FASTTRACK_ENABLED:false}
     llm:
       provider: ${LLM_PROVIDER:openai}
       base-url: ${LLM_BASE_URL:https://api.openai.com/v1}

--- a/lmos-runtime-service/src/test/resources/application.yaml
+++ b/lmos-runtime-service/src/test/resources/application.yaml
@@ -20,10 +20,3 @@ lmos:
           display-name: Tenant 1
         - id: tenant2
           display-name: Tenant 2
-  router:
-    classifier:
-      llm:
-        enabled: true
-    llm:
-      provider: openai
-      model: dummy-model

--- a/lmos-runtime-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/runtime/config/RuntimeAutoConfiguration.kt
+++ b/lmos-runtime-spring-boot-starter/src/main/kotlin/org/eclipse/lmos/runtime/config/RuntimeAutoConfiguration.kt
@@ -38,6 +38,7 @@ import org.eclipse.lmos.runtime.properties.Type
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -107,6 +108,11 @@ class RuntimeAutoConfiguration(
 
     @Bean
     @ConditionalOnMissingBean(AgentClassifierService::class)
+    @ConditionalOnExpression(
+        "'\${lmos.router.classifier.vector.enabled:false}' == 'true' || " +
+            "'\${lmos.router.classifier.llm.enabled:false}' == 'true' || " +
+            "'\${lmos.router.classifier.hybrid-fast-track.enabled:false}' == 'true'",
+    )
     fun agentClassifierService(classifier: AgentClassifier): AgentClassifierService = DefaultAgentClassifierService(classifier)
 
     @Bean
@@ -157,14 +163,14 @@ class RuntimeAutoConfiguration(
     @ConditionalOnMissingBean(ConversationHandler::class)
     fun conversationHandler(
         agentRoutingService: AgentRoutingService,
-        agentClassifierService: AgentClassifierService,
+        agentClassifierServiceProvider: ObjectProvider<AgentClassifierService>,
         cachedChannelRoutingRepository: CachedChannelRoutingRepository,
         agentClientService: AgentClientService,
         disambiguationHandlerProvider: ObjectProvider<DisambiguationHandler>,
     ): ConversationHandler =
         DefaultConversationHandler(
             agentRoutingService,
-            agentClassifierService,
+            agentClassifierServiceProvider.ifAvailable,
             cachedChannelRoutingRepository,
             agentClientService,
             disambiguationHandlerProvider.ifAvailable,


### PR DESCRIPTION
Activate classifier only when at least one classifier is enabled via configuration instead of activation by feature keys.